### PR TITLE
fix: S3 operations, PostgreSQL compatibility, EXIF safety, and dark mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,28 @@
 # CHANGELOG for unopim-digital-asset-management
 
+## Version 2.0.1 - Bug Fix Release
+Compatible with UnoPim v2.0.0
+
+### Fixed
+
+- S3 — Single asset move
+Fixed an issue where moving a single asset on S3 orphaned the object.
+
+- S3 — Directory rename
+Fixed directory move by relocating files individually (S3 doesn't support directory operations).
+
+- S3 — Asset metadata
+Fixed metadata extraction by using temporary local copies and storage-level values.
+
+- Missing EXIF extension
+Prevented fatal errors when EXIF extension is not installed.
+
+- PostgreSQL — SQL compatibility
+Fixed MySQL-specific queries causing errors on PostgreSQL.
+
+- Dark mode — Root Category label
+Fixed text visibility in dark mode.
+
 ## **Version 2.0.0** - UnoPim v2.0.0 Compatibility
 
 > Compatible with **UnoPim v2.0.0**

--- a/src/DataGrids/Asset/AssetDataGrid.php
+++ b/src/DataGrids/Asset/AssetDataGrid.php
@@ -36,14 +36,13 @@ class AssetDataGrid extends DataGrid
     public function prepareQueryBuilder()
     {
         $queryBuilder = DB::table('dam_directories')
-            ->distinct()
             ->join('dam_asset_directory', 'dam_directories.id', '=', 'dam_asset_directory.directory_id')
             ->join('dam_assets', 'dam_asset_directory.asset_id', '=', 'dam_assets.id')
             ->leftJoin('dam_asset_properties', 'dam_assets.id', '=', 'dam_asset_properties.dam_asset_id')
             ->leftJoin('dam_asset_tag', 'dam_assets.id', '=', 'dam_asset_tag.asset_id')
             ->leftJoin('dam_tags', 'dam_asset_tag.tag_id', '=', 'dam_tags.id')
             ->select(
-                'dam_directories.id as directory_id',
+                DB::raw('MIN(dam_directories.id) as directory_id'),
                 'dam_assets.id',
                 'dam_assets.file_name',
                 'dam_assets.file_type',
@@ -53,7 +52,7 @@ class AssetDataGrid extends DataGrid
                 'dam_assets.path',
                 'dam_assets.created_at',
                 'dam_assets.updated_at',
-                'dam_asset_directory.asset_id as directory_asset_id',
+                DB::raw('MIN(dam_asset_directory.asset_id) as directory_asset_id'),
             )
             ->groupBy('dam_assets.id');
 

--- a/src/Http/Controllers/API/Asset/TagController.php
+++ b/src/Http/Controllers/API/Asset/TagController.php
@@ -59,7 +59,7 @@ class TagController extends Controller
             ], 404);
         }
 
-        $assetTag = $this->assetTagRepository->where('name', $newTag)->first();
+        $assetTag = $this->assetTagRepository->whereRaw('LOWER(name) = ?', [mb_strtolower($newTag)])->first();
 
         $oldTags = $asset->tags->pluck('name')->toArray();
 
@@ -116,7 +116,7 @@ class TagController extends Controller
             ], 404);
         }
 
-        $assetTag = $this->assetTagRepository->where('name', $newTag)->first();
+        $assetTag = $this->assetTagRepository->whereRaw('LOWER(name) = ?', [mb_strtolower($newTag)])->first();
 
         $oldTags = $asset->tags->pluck('name')->toArray();
 

--- a/src/Http/Controllers/Asset/AssetController.php
+++ b/src/Http/Controllers/Asset/AssetController.php
@@ -630,17 +630,29 @@ class AssetController extends Controller
             ], 500);
         }
 
+        $oldAssetFullPath = $asset->path;
+
         $asset->directories()->sync($request->input('new_parent_id'));
         $newDirectory = $asset->directories()->first();
         $directoryPath = sprintf('%s/%s', Directory::ASSETS_DIRECTORY, $newDirectory->generatePath());
         $uniqueFileName = $this->generateUniqueFileName($directoryPath, $asset->file_name);
         $newPath = sprintf('%s/%s', $newDirectory->generatePath(), $uniqueFileName);
+        $newAssetFullPath = sprintf('%s/%s', Directory::ASSETS_DIRECTORY, $newPath);
         $asset->update([
-            'path'      => sprintf('%s/%s', Directory::ASSETS_DIRECTORY, $newPath),
+            'path'      => $newAssetFullPath,
             'file_name' => $uniqueFileName,
         ]);
 
-        $this->directoryRepository->createDirectoryWithStorage($newPath, $oldPath);
+        $disk = Directory::getAssetDisk();
+        Storage::disk($disk)->makeDirectory($directoryPath);
+
+        if (
+            $oldAssetFullPath
+            && $oldAssetFullPath !== $newAssetFullPath
+            && Storage::disk($disk)->exists($oldAssetFullPath)
+        ) {
+            Storage::disk($disk)->move($oldAssetFullPath, $newAssetFullPath);
+        }
 
         return new JsonResponse([
             'data'    => $asset,

--- a/src/Http/Controllers/Asset/TagController.php
+++ b/src/Http/Controllers/Asset/TagController.php
@@ -45,7 +45,7 @@ class TagController extends Controller
             ], 404);
         }
 
-        $assetTag = $this->assetTagRepository->where('name', $newTag)->first();
+        $assetTag = $this->assetTagRepository->whereRaw('LOWER(name) = ?', [mb_strtolower($newTag)])->first();
 
         $oldTags = $asset->tags->pluck('name')->toArray();
 
@@ -106,7 +106,7 @@ class TagController extends Controller
             ], 404);
         }
 
-        $assetTag = $this->assetTagRepository->where('name', $newTag)->first();
+        $assetTag = $this->assetTagRepository->whereRaw('LOWER(name) = ?', [mb_strtolower($newTag)])->first();
 
         $oldTags = $asset->tags->pluck('name')->toArray();
 

--- a/src/Jobs/MoveDirectoryStructure.php
+++ b/src/Jobs/MoveDirectoryStructure.php
@@ -6,6 +6,8 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Webkul\DAM\Enums\EventType;
 use Webkul\DAM\Models\Directory as ModelDirectory;
 use Webkul\DAM\Repositories\DirectoryRepository;
@@ -91,8 +93,42 @@ class MoveDirectoryStructure
     public function moveAssets(ModelDirectory $directory): void
     {
         $path = $directory->generatePath();
+        $disk = ModelDirectory::getAssetDisk();
+        // On object stores like S3 there are no real directories, so the
+        // folder-level rename performed later is a no-op and assets would be
+        // orphaned. Move each file individually for those drivers.
+        $movePerFile = $disk === ModelDirectory::ASSETS_DISK_AWS;
+
         foreach ($directory->assets()->get() as $asset) {
-            $asset->update(['path' => sprintf('%s/%s/%s', ModelDirectory::ASSETS_DIRECTORY, $path, $asset->file_name)]);
+            $oldAssetPath = $asset->path;
+            $newAssetPath = sprintf('%s/%s/%s', ModelDirectory::ASSETS_DIRECTORY, $path, $asset->file_name);
+
+            if (
+                $movePerFile
+                && $oldAssetPath
+                && $oldAssetPath !== $newAssetPath
+            ) {
+                try {
+                    if (
+                        Storage::disk($disk)->exists($oldAssetPath)
+                        && ! Storage::disk($disk)->exists($newAssetPath)
+                    ) {
+                        Storage::disk($disk)->move($oldAssetPath, $newAssetPath);
+                    }
+                } catch (\Throwable $e) {
+                    Log::error('DAM: failed to move asset file on storage', [
+                        'asset_id' => $asset->id,
+                        'from'     => $oldAssetPath,
+                        'to'       => $newAssetPath,
+                        'disk'     => $disk,
+                        'error'    => $e->getMessage(),
+                    ]);
+
+                    throw $e;
+                }
+            }
+
+            $asset->update(['path' => $newAssetPath]);
         }
     }
 }

--- a/src/Repositories/DirectoryRepository.php
+++ b/src/Repositories/DirectoryRepository.php
@@ -140,7 +140,17 @@ class DirectoryRepository extends Repository
             }
 
             $oldDirectory = sprintf('%s/%s', Directory::ASSETS_DIRECTORY, $oldPath);
-            $disk = Directory::getAssetDisk();
+
+            // On object stores like S3 there are no real directories; asset
+            // files are moved individually by the caller (see
+            // MoveDirectoryStructure::moveAssets), so just clean up the old
+            // prefix if anything is left and ensure the new one exists.
+            if ($disk === Directory::ASSETS_DISK_AWS) {
+                Storage::disk($disk)->deleteDirectory($oldDirectory);
+                Storage::disk($disk)->makeDirectory($newDirectory);
+
+                return;
+            }
 
             // Check if a directory exists
             if (Storage::disk($disk)->exists($oldDirectory)) {

--- a/src/Resources/lang/en_AU/app.php
+++ b/src/Resources/lang/en_AU/app.php
@@ -27,8 +27,7 @@ return [
         ],
         'dam' => [
             'index' => [
-                'title' => 'DAM',
-
+                'title'    => 'DAM',
                 'datagrid' => [
                     'file-name'      => 'File Name',
                     'tags'           => 'Tags',
@@ -40,26 +39,22 @@ return [
                     'path'           => 'Path',
                     'size'           => 'Size',
                 ],
-
                 'directory' => [
-                    'title'        => 'Directory',
-                    'create'       => [
+                    'title'  => 'Directory',
+                    'create' => [
                         'title'    => 'Create Directory',
                         'name'     => 'Name',
                         'save-btn' => 'Save Directory',
                     ],
-
                     'rename' => [
                         'title' => 'Rename Directory',
                     ],
-
                     'asset' => [
                         'rename' => [
                             'title'    => 'Rename Asset',
                             'save-btn' => 'Save Asset',
                         ],
                     ],
-
                     'actions' => [
                         'delete'                    => 'Delete',
                         'rename'                    => 'Rename',
@@ -73,7 +68,6 @@ return [
                         'get-by-id'                 => 'Get By Id',
                         'comment'                   => 'Comment',
                     ],
-
                     'linked-resources'                          => 'Linked Resources',
                     'not-found'                                 => 'No directory found',
                     'created-success'                           => 'Directory created successfully',
@@ -82,23 +76,21 @@ return [
                     'fetch-all-success'                         => 'Directories fetched successfully',
                     'can-not-deleted'                           => 'Directory cannot be deleted as it is Root Directory.',
                     'deleting-in-progress'                      => 'Directory deleting in-progress',
-                    'can-not-copy'                              => 'Directory cannot be copy as it is Root Directory.',
-                    'coping-in-progress'                        => 'Directory structure coping in-progress.',
+                    'can-not-copy'                              => 'Directory cannot be copied as it is Root Directory.',
+                    'coping-in-progress'                        => 'Directory structure copying in-progress.',
                     'asset-not-found'                           => 'No asset found',
                     'asset-renamed-success'                     => 'Asset renamed successfully',
                     'asset-moved-success'                       => 'Asset moved successfully',
                     'asset-name-already-exist'                  => 'The new name already exists with another asset named :asset_name',
                     'asset-name-conflict-in-the-same-directory' => 'The asset name conflicts with an existing file in the same directory.',
                     'old-file-not-found'                        => 'The file requested at the path :old_path was not found.',
-                    'image-name-is-the-same'                    => 'This name is already exist. Please enter a different one.',
+                    'image-name-is-the-same'                    => 'This name is already in use. Please enter a different one.',
                     'not-writable'                              => 'You are not allowed to :actionType a :type in this location ":path".',
                     'empty-directory'                           => 'This directory is empty.',
                     'failed-download-directory'                 => 'Failed to create the zip file.',
                     'not-allowed'                               => 'Uploading script files is not allowed.',
                 ],
-
-                'title'       => 'DAM',
-                'description' => 'Tool can help you organise, store, and manage all your media asset in one place',
+                'description' => 'Tool can help you organise, store, and manage all your media assets in one place',
                 'root'        => 'Root',
                 'upload'      => 'Upload',
             ],
@@ -107,8 +99,7 @@ return [
                     'index' => [
                         'title'      => 'Asset Properties',
                         'create-btn' => 'Create Property',
-
-                        'datagrid'      => [
+                        'datagrid'   => [
                             'name'     => 'Name',
                             'type'     => 'Type',
                             'language' => 'Language',
@@ -116,8 +107,7 @@ return [
                             'edit'     => 'Edit',
                             'delete'   => 'Delete',
                         ],
-
-                        'create'     => [
+                        'create' => [
                             'title'    => 'Create Property',
                             'name'     => 'Name',
                             'type'     => 'Type',
@@ -148,10 +138,10 @@ return [
                     'add-comment'     => 'Add Comment',
                     'no-comments'     => 'No Comments Yet',
                     'not-found'       => 'Comments Not Found',
-                    'updated-success' => 'Comment updated Successfully',
+                    'updated-success' => 'Comment updated successfully',
                     'update-failed'   => 'Comment failed to update',
                     'delete-success'  => 'Asset Comment Deleted Successfully',
-                    'delete-failed'   => 'Asset Comment failed to delete',
+                    'delete-failed'   => 'Asset comment failed to delete',
                 ],
                 'edit' => [
                     'title'              => 'Edit Asset',
@@ -162,7 +152,7 @@ return [
                     'embedded_meta_info' => 'Embedded Meta Info',
                     'custom_meta_info'   => 'Custom Meta Info',
                     'tags'               => 'Tags',
-                    'select-tags'        => 'Choose or Create a Tag',
+                    'select-tags'        => 'Choose or create a tag',
                     'tag'                => 'Tag',
                     'directory-path'     => 'Directory Path',
                     'add_tags'           => 'Add Tags',
@@ -180,7 +170,6 @@ return [
                         're_upload'       => 'Re-Upload',
                         'delete'          => 'Delete',
                     ],
-
                     'custom-download' => [
                         'title'              => 'Custom Download',
                         'format'             => 'Format',
@@ -189,8 +178,7 @@ return [
                         'height'             => 'Height (px)',
                         'height-placeholder' => '200',
                         'download-btn'       => 'Download',
-
-                        'extension-types' => [
+                        'extension-types'    => [
                             'jpg'      => 'JPG',
                             'png'      => 'PNG',
                             'jpeg'     => 'JPEG',
@@ -198,20 +186,18 @@ return [
                             'original' => 'Original',
                         ],
                     ],
-
                     'tag-already-exists'        => 'Tag already exists',
                     'image-source-not-readable' => 'Image source not readable',
                     'failed-to-read'            => 'Failed to read image metadata :exception',
-                    'file-re-upload-success'    => 'Files Re-Uploaded Successfully.',
-
+                    'file-re-upload-success'    => 'Files re-uploaded successfully',
                 ],
                 'linked-resources' => [
                     'index' => [
                         'datagrid' => [
                             'product'       => 'Product',
                             'category'      => 'Category',
-                            'product-sku'   => 'Product Sku: ',
-                            'category code' => 'Category Code: ',
+                            'product-sku'   => 'Product SKU: ',
+                            'category code' => 'Category code: ',
                             'resource-type' => 'Resource Type',
                             'resource'      => 'Resource',
                             'resource-view' => 'Resource View',
@@ -223,39 +209,38 @@ return [
                 'tags' => [
                     'index'  => 'Add tags',
                     'create' => [
-                        'create-success' => 'Tags has been successfully added',
+                        'create-success' => 'Tags have been successfully added',
                         'create-failure' => 'Tags failed to create',
                     ],
-
                     'no-comments'    => 'No Tags Yet',
                     'found-success'  => 'Tag Found Successfully',
                     'not-found'      => 'Tags Not Found',
-                    'update-success' => 'Tags updated Successfully',
+                    'update-success' => 'Tags updated successfully',
                     'update-failed'  => 'Tags failed to update',
                     'delete-success' => 'Asset Tags Removed Successfully',
-                    'delete-failed'  => 'Asset Tags failed to delete',
+                    'delete-failed'  => 'Asset tags failed to delete',
                 ],
                 'delete-success'                          => 'Asset deleted successfully',
-                'delete-failed-due-to-attached-resources' => 'Asset in use. Unlink before deleting',
+                'delete-failed-due-to-attached-resources' => 'Asset in use, unlink before deleting',
                 'datagrid'                                => [
                     'mass-delete-success'                 => 'Mass Deleted Successfully.',
                     'files-upload-success'                => 'Files Uploaded Successfully.',
                     'file-upload-success'                 => 'File Uploaded Successfully.',
-                    'not-found'                           => 'File not Found',
+                    'not-found'                           => 'File not found',
                     'edit-success'                        => 'File Uploaded Successfully',
                     'show-success'                        => 'File Found Successfully',
                     'update-success'                      => 'File Updated Successfully',
-                    'not-found-to-update'                 => 'File does not Exits',
-                    'not-found-to-destroy'                => 'File does not Exits',
-                    'files-upload-failed'                 => 'Files failed to upload.',
+                    'not-found-to-update'                 => 'File does not exist',
+                    'not-found-to-destroy'                => 'File does not exist',
+                    'files-upload-failed'                 => 'Files failed to upload',
                     'file-upload-failed'                  => 'File failed to upload',
                     'invalid-file'                        => 'Invalid File Provided',
                     'invalid-file-format'                 => 'Invalid Format',
-                    'invalid-file-format-or-not-provided' => 'No files provided or invalid format.',
+                    'invalid-file-format-or-not-provided' => 'No files provided or invalid format',
                     'download-image-failed'               => 'Failed to download image from URL',
                     'file-process-failed'                 => 'Some files failed to process',
-                    'file-forbidden-type'                 => 'File has forbidden type or extension.',
-                    'file-too-large'                      => 'The file is too large. Maximum allowed size is :size.',
+                    'file-forbidden-type'                 => 'File has forbidden type or extension',
+                    'file-too-large'                      => 'The file is too large. Maximum allowed size is :size',
                 ],
             ],
         ],
@@ -298,33 +283,30 @@ return [
             'download-zip'     => 'Download Zip',
             'asset-assign'     => 'Assign Asset',
         ],
-
         'validation' => [
             'asset' => [
-                'required' => 'The :attribute field is required.',
+                'required' => 'The :attribute field is required',
             ],
-
             'comment' => [
-                'required' => 'The Comment message is required.',
+                'required' => 'The Comment message is required',
             ],
             'tag' => [
                 'name' => [
-                    'required' => 'The Tag field is required.',
+                    'required' => 'The Tag field is required',
                 ],
             ],
             'property' => [
                 'name' => [
-                    'required' => 'The Name field is required.',
-                    'unique'   => 'The Name has already been taken.',
+                    'required' => 'The Name field is required',
+                    'unique'   => 'The Name has already been taken',
                 ],
                 'language' => [
-                    'not-found' => 'The selected language could not be found or is currently disabled.',
+                    'not-found' => 'The selected language could not be found or is currently disabled',
                 ],
             ],
         ],
-
         'errors' => [
-            '401' => 'This action is unauthorized.',
+            '401' => 'This action is unauthorised.',
         ],
     ],
 ];

--- a/src/Resources/lang/en_GB/app.php
+++ b/src/Resources/lang/en_GB/app.php
@@ -27,8 +27,7 @@ return [
         ],
         'dam' => [
             'index' => [
-                'title' => 'DAM',
-
+                'title'    => 'DAM',
                 'datagrid' => [
                     'file-name'      => 'File Name',
                     'tags'           => 'Tags',
@@ -40,26 +39,22 @@ return [
                     'path'           => 'Path',
                     'size'           => 'Size',
                 ],
-
                 'directory' => [
-                    'title'        => 'Directory',
-                    'create'       => [
+                    'title'  => 'Directory',
+                    'create' => [
                         'title'    => 'Create Directory',
                         'name'     => 'Name',
                         'save-btn' => 'Save Directory',
                     ],
-
                     'rename' => [
                         'title' => 'Rename Directory',
                     ],
-
                     'asset' => [
                         'rename' => [
                             'title'    => 'Rename Asset',
                             'save-btn' => 'Save Asset',
                         ],
                     ],
-
                     'actions' => [
                         'delete'                    => 'Delete',
                         'rename'                    => 'Rename',
@@ -73,7 +68,6 @@ return [
                         'get-by-id'                 => 'Get By Id',
                         'comment'                   => 'Comment',
                     ],
-
                     'linked-resources'                          => 'Linked Resources',
                     'not-found'                                 => 'No directory found',
                     'created-success'                           => 'Directory created successfully',
@@ -82,23 +76,21 @@ return [
                     'fetch-all-success'                         => 'Directories fetched successfully',
                     'can-not-deleted'                           => 'Directory cannot be deleted as it is Root Directory.',
                     'deleting-in-progress'                      => 'Directory deleting in-progress',
-                    'can-not-copy'                              => 'Directory cannot be copy as it is Root Directory.',
-                    'coping-in-progress'                        => 'Directory structure coping in-progress.',
+                    'can-not-copy'                              => 'Directory cannot be copied as it is Root Directory.',
+                    'coping-in-progress'                        => 'Directory structure copying in-progress.',
                     'asset-not-found'                           => 'No asset found',
                     'asset-renamed-success'                     => 'Asset renamed successfully',
                     'asset-moved-success'                       => 'Asset moved successfully',
                     'asset-name-already-exist'                  => 'The new name already exists with another asset named :asset_name',
                     'asset-name-conflict-in-the-same-directory' => 'The asset name conflicts with an existing file in the same directory.',
                     'old-file-not-found'                        => 'The file requested at the path :old_path was not found.',
-                    'image-name-is-the-same'                    => 'This name is already exist. Please enter a different one.',
-                    'not-writable'                              => 'You are not allowed to :actionType a :type in this location ":path".',
+                    'image-name-is-the-same'                    => 'This name is already in use. Please enter a different one.',
+                    'not-writable'                              => 'You are not allowed to :actionType a :type in this location":path".',
                     'empty-directory'                           => 'This directory is empty.',
                     'failed-download-directory'                 => 'Failed to create the zip file.',
                     'not-allowed'                               => 'Uploading script files is not allowed.',
                 ],
-
-                'title'       => 'DAM',
-                'description' => 'Tool can help you organise, store, and manage all your media asset in one place',
+                'description' => 'Tool can help you organise, store, and manage all your media assets in one place',
                 'root'        => 'Root',
                 'upload'      => 'Upload',
             ],
@@ -107,8 +99,7 @@ return [
                     'index' => [
                         'title'      => 'Asset Properties',
                         'create-btn' => 'Create Property',
-
-                        'datagrid'      => [
+                        'datagrid'   => [
                             'name'     => 'Name',
                             'type'     => 'Type',
                             'language' => 'Language',
@@ -116,8 +107,7 @@ return [
                             'edit'     => 'Edit',
                             'delete'   => 'Delete',
                         ],
-
-                        'create'     => [
+                        'create' => [
                             'title'    => 'Create Property',
                             'name'     => 'Name',
                             'type'     => 'Type',
@@ -180,7 +170,6 @@ return [
                         're_upload'       => 'Re-Upload',
                         'delete'          => 'Delete',
                     ],
-
                     'custom-download' => [
                         'title'              => 'Custom Download',
                         'format'             => 'Format',
@@ -189,8 +178,7 @@ return [
                         'height'             => 'Height (px)',
                         'height-placeholder' => '200',
                         'download-btn'       => 'Download',
-
-                        'extension-types' => [
+                        'extension-types'    => [
                             'jpg'      => 'JPG',
                             'png'      => 'PNG',
                             'jpeg'     => 'JPEG',
@@ -198,12 +186,10 @@ return [
                             'original' => 'Original',
                         ],
                     ],
-
                     'tag-already-exists'        => 'Tag already exists',
                     'image-source-not-readable' => 'Image source not readable',
                     'failed-to-read'            => 'Failed to read image metadata :exception',
-                    'file-re-upload-success'    => 'Files Re-Uploaded Successfully.',
-
+                    'file-re-upload-success'    => 'Files Re-Uploaded Successfully',
                 ],
                 'linked-resources' => [
                     'index' => [
@@ -223,10 +209,9 @@ return [
                 'tags' => [
                     'index'  => 'Add tags',
                     'create' => [
-                        'create-success' => 'Tags has been successfully added',
+                        'create-success' => 'Tags have been successfully added',
                         'create-failure' => 'Tags failed to create',
                     ],
-
                     'no-comments'    => 'No Tags Yet',
                     'found-success'  => 'Tag Found Successfully',
                     'not-found'      => 'Tags Not Found',
@@ -245,13 +230,13 @@ return [
                     'edit-success'                        => 'File Uploaded Successfully',
                     'show-success'                        => 'File Found Successfully',
                     'update-success'                      => 'File Updated Successfully',
-                    'not-found-to-update'                 => 'File does not Exits',
-                    'not-found-to-destroy'                => 'File does not Exits',
-                    'files-upload-failed'                 => 'Files failed to upload.',
+                    'not-found-to-update'                 => 'File does not exist',
+                    'not-found-to-destroy'                => 'File does not exist',
+                    'files-upload-failed'                 => 'Files failed to upload',
                     'file-upload-failed'                  => 'File failed to upload',
                     'invalid-file'                        => 'Invalid File Provided',
                     'invalid-file-format'                 => 'Invalid Format',
-                    'invalid-file-format-or-not-provided' => 'No files provided or invalid format.',
+                    'invalid-file-format-or-not-provided' => 'No files provided or invalid format',
                     'download-image-failed'               => 'Failed to download image from URL',
                     'file-process-failed'                 => 'Some files failed to process',
                     'file-forbidden-type'                 => 'File has forbidden type or extension.',
@@ -298,12 +283,10 @@ return [
             'download-zip'     => 'Download Zip',
             'asset-assign'     => 'Assign Asset',
         ],
-
         'validation' => [
             'asset' => [
                 'required' => 'The :attribute field is required.',
             ],
-
             'comment' => [
                 'required' => 'The Comment message is required.',
             ],
@@ -322,9 +305,8 @@ return [
                 ],
             ],
         ],
-
         'errors' => [
-            '401' => 'This action is unauthorized.',
+            '401' => 'This action is unauthorised.',
         ],
     ],
 ];

--- a/src/Resources/lang/en_NZ/app.php
+++ b/src/Resources/lang/en_NZ/app.php
@@ -27,8 +27,7 @@ return [
         ],
         'dam' => [
             'index' => [
-                'title' => 'DAM',
-
+                'title'    => 'DAM',
                 'datagrid' => [
                     'file-name'      => 'File Name',
                     'tags'           => 'Tags',
@@ -40,26 +39,22 @@ return [
                     'path'           => 'Path',
                     'size'           => 'Size',
                 ],
-
                 'directory' => [
-                    'title'        => 'Directory',
-                    'create'       => [
+                    'title'  => 'Directory',
+                    'create' => [
                         'title'    => 'Create Directory',
                         'name'     => 'Name',
                         'save-btn' => 'Save Directory',
                     ],
-
                     'rename' => [
                         'title' => 'Rename Directory',
                     ],
-
                     'asset' => [
                         'rename' => [
                             'title'    => 'Rename Asset',
                             'save-btn' => 'Save Asset',
                         ],
                     ],
-
                     'actions' => [
                         'delete'                    => 'Delete',
                         'rename'                    => 'Rename',
@@ -73,7 +68,6 @@ return [
                         'get-by-id'                 => 'Get By Id',
                         'comment'                   => 'Comment',
                     ],
-
                     'linked-resources'                          => 'Linked Resources',
                     'not-found'                                 => 'No directory found',
                     'created-success'                           => 'Directory created successfully',
@@ -82,23 +76,21 @@ return [
                     'fetch-all-success'                         => 'Directories fetched successfully',
                     'can-not-deleted'                           => 'Directory cannot be deleted as it is Root Directory.',
                     'deleting-in-progress'                      => 'Directory deleting in-progress',
-                    'can-not-copy'                              => 'Directory cannot be copy as it is Root Directory.',
-                    'coping-in-progress'                        => 'Directory structure coping in-progress.',
+                    'can-not-copy'                              => 'Directory cannot be copied as it is Root Directory.',
+                    'coping-in-progress'                        => 'Directory structure copying in-progress.',
                     'asset-not-found'                           => 'No asset found',
                     'asset-renamed-success'                     => 'Asset renamed successfully',
                     'asset-moved-success'                       => 'Asset moved successfully',
                     'asset-name-already-exist'                  => 'The new name already exists with another asset named :asset_name',
                     'asset-name-conflict-in-the-same-directory' => 'The asset name conflicts with an existing file in the same directory.',
                     'old-file-not-found'                        => 'The file requested at the path :old_path was not found.',
-                    'image-name-is-the-same'                    => 'This name is already exist. Please enter a different one.',
+                    'image-name-is-the-same'                    => 'This name is already in use. Please enter a different one.',
                     'not-writable'                              => 'You are not allowed to :actionType a :type in this location ":path".',
                     'empty-directory'                           => 'This directory is empty.',
                     'failed-download-directory'                 => 'Failed to create the zip file.',
                     'not-allowed'                               => 'Uploading script files is not allowed.',
                 ],
-
-                'title'       => 'DAM',
-                'description' => 'Tool can help you organise, store, and manage all your media asset in one place',
+                'description' => 'Tool can help you organise, store, and manage all your media assets in one place',
                 'root'        => 'Root',
                 'upload'      => 'Upload',
             ],
@@ -107,8 +99,7 @@ return [
                     'index' => [
                         'title'      => 'Asset Properties',
                         'create-btn' => 'Create Property',
-
-                        'datagrid'      => [
+                        'datagrid'   => [
                             'name'     => 'Name',
                             'type'     => 'Type',
                             'language' => 'Language',
@@ -116,8 +107,7 @@ return [
                             'edit'     => 'Edit',
                             'delete'   => 'Delete',
                         ],
-
-                        'create'     => [
+                        'create' => [
                             'title'    => 'Create Property',
                             'name'     => 'Name',
                             'type'     => 'Type',
@@ -148,10 +138,10 @@ return [
                     'add-comment'     => 'Add Comment',
                     'no-comments'     => 'No Comments Yet',
                     'not-found'       => 'Comments Not Found',
-                    'updated-success' => 'Comment updated Successfully',
+                    'updated-success' => 'Comment updated successfully',
                     'update-failed'   => 'Comment failed to update',
                     'delete-success'  => 'Asset Comment Deleted Successfully',
-                    'delete-failed'   => 'Asset Comment failed to delete',
+                    'delete-failed'   => 'Asset comment failed to delete',
                 ],
                 'edit' => [
                     'title'              => 'Edit Asset',
@@ -162,7 +152,7 @@ return [
                     'embedded_meta_info' => 'Embedded Meta Info',
                     'custom_meta_info'   => 'Custom Meta Info',
                     'tags'               => 'Tags',
-                    'select-tags'        => 'Choose or Create a Tag',
+                    'select-tags'        => 'Choose or create a tag',
                     'tag'                => 'Tag',
                     'directory-path'     => 'Directory Path',
                     'add_tags'           => 'Add Tags',
@@ -180,7 +170,6 @@ return [
                         're_upload'       => 'Re-Upload',
                         'delete'          => 'Delete',
                     ],
-
                     'custom-download' => [
                         'title'              => 'Custom Download',
                         'format'             => 'Format',
@@ -189,8 +178,7 @@ return [
                         'height'             => 'Height (px)',
                         'height-placeholder' => '200',
                         'download-btn'       => 'Download',
-
-                        'extension-types' => [
+                        'extension-types'    => [
                             'jpg'      => 'JPG',
                             'png'      => 'PNG',
                             'jpeg'     => 'JPEG',
@@ -198,20 +186,18 @@ return [
                             'original' => 'Original',
                         ],
                     ],
-
                     'tag-already-exists'        => 'Tag already exists',
                     'image-source-not-readable' => 'Image source not readable',
                     'failed-to-read'            => 'Failed to read image metadata :exception',
-                    'file-re-upload-success'    => 'Files Re-Uploaded Successfully.',
-
+                    'file-re-upload-success'    => 'Files re-uploaded successfully',
                 ],
                 'linked-resources' => [
                     'index' => [
                         'datagrid' => [
                             'product'       => 'Product',
                             'category'      => 'Category',
-                            'product-sku'   => 'Product Sku: ',
-                            'category code' => 'Category Code: ',
+                            'product-sku'   => 'Product SKU: ',
+                            'category code' => 'Category code: ',
                             'resource-type' => 'Resource Type',
                             'resource'      => 'Resource',
                             'resource-view' => 'Resource View',
@@ -223,35 +209,34 @@ return [
                 'tags' => [
                     'index'  => 'Add tags',
                     'create' => [
-                        'create-success' => 'Tags has been successfully added',
+                        'create-success' => 'Tags have been successfully added',
                         'create-failure' => 'Tags failed to create',
                     ],
-
                     'no-comments'    => 'No Tags Yet',
                     'found-success'  => 'Tag Found Successfully',
                     'not-found'      => 'Tags Not Found',
-                    'update-success' => 'Tags updated Successfully',
+                    'update-success' => 'Tags updated successfully',
                     'update-failed'  => 'Tags failed to update',
                     'delete-success' => 'Asset Tags Removed Successfully',
-                    'delete-failed'  => 'Asset Tags failed to delete',
+                    'delete-failed'  => 'Asset tags failed to delete',
                 ],
                 'delete-success'                          => 'Asset deleted successfully',
-                'delete-failed-due-to-attached-resources' => 'Asset in use. Unlink before deleting',
+                'delete-failed-due-to-attached-resources' => 'Asset in use, unlink before deleting',
                 'datagrid'                                => [
                     'mass-delete-success'                 => 'Mass Deleted Successfully.',
                     'files-upload-success'                => 'Files Uploaded Successfully.',
                     'file-upload-success'                 => 'File Uploaded Successfully.',
-                    'not-found'                           => 'File not Found',
+                    'not-found'                           => 'File not found',
                     'edit-success'                        => 'File Uploaded Successfully',
                     'show-success'                        => 'File Found Successfully',
                     'update-success'                      => 'File Updated Successfully',
-                    'not-found-to-update'                 => 'File does not Exits',
-                    'not-found-to-destroy'                => 'File does not Exits',
-                    'files-upload-failed'                 => 'Files failed to upload.',
+                    'not-found-to-update'                 => 'File does not exist',
+                    'not-found-to-destroy'                => 'File does not exist',
+                    'files-upload-failed'                 => 'Files failed to upload',
                     'file-upload-failed'                  => 'File failed to upload',
                     'invalid-file'                        => 'Invalid File Provided',
                     'invalid-file-format'                 => 'Invalid Format',
-                    'invalid-file-format-or-not-provided' => 'No files provided or invalid format.',
+                    'invalid-file-format-or-not-provided' => 'No files provided or invalid format',
                     'download-image-failed'               => 'Failed to download image from URL',
                     'file-process-failed'                 => 'Some files failed to process',
                     'file-forbidden-type'                 => 'File has forbidden type or extension.',
@@ -298,12 +283,10 @@ return [
             'download-zip'     => 'Download Zip',
             'asset-assign'     => 'Assign Asset',
         ],
-
         'validation' => [
             'asset' => [
                 'required' => 'The :attribute field is required.',
             ],
-
             'comment' => [
                 'required' => 'The Comment message is required.',
             ],
@@ -322,9 +305,8 @@ return [
                 ],
             ],
         ],
-
         'errors' => [
-            '401' => 'This action is unauthorized.',
+            '401' => 'This action is unauthorised.',
         ],
     ],
 ];

--- a/src/Resources/views/components/asset/picker/directory-tree.blade.php
+++ b/src/Resources/views/components/asset/picker/directory-tree.blade.php
@@ -36,7 +36,7 @@
                     </span>
                     <span 
                         class="text-sm text-nowrap overflow-hidden text-ellipsis"
-                         :class="selectedItem && formattedItems[0].id == selectedItem.id ? 'text-violet-700 dark:text-violet-400' : 'text-zinc-600 dark:text-gray-300'"
+                         :class="selectedItem && formattedItems[0].id == selectedItem.id ? 'text-violet-700 dark:text-violet-400 font-semibold' : 'text-zinc-600 dark:text-gray-300'"
                     >
                         @{{ formattedItems[0].name }}
                     </span>
@@ -195,7 +195,7 @@
                 </span>
                 <span 
                     class="text-sm flex items-center gap-1"
-                    :class="selectedItem && item.id == selectedItem.id ? 'text-violet-700 dark:text-violet-400' : 'text-zinc-600 dark:text-gray-300'"
+                    :class="selectedItem && item.id == selectedItem.id ? 'text-violet-700 dark:text-violet-400 font-semibold' : 'text-zinc-600 dark:text-gray-300'"
                 >
                     <i class="icon-dam-folder text-xl transition-all group-hover:text-gray-800 dark:group-hover:text-white"></i>
 
@@ -292,7 +292,7 @@
                 </span>
                 <span 
                     class="text-sm"
-                    :class="selectedItem && selectedItem.file_name && item.id == selectedItem.id ? 'text-violet-700 dark:text-violet-400' : 'text-zinc-600 dark:text-gray-300'"
+                    :class="selectedItem && selectedItem.file_name && item.id == selectedItem.id ? 'text-violet-700 dark:text-violet-400 font-semibold' : 'text-zinc-600 dark:text-gray-300'"
                 >
                     @{{ item.file_name }}
                 </span>

--- a/src/Resources/views/components/tree/damdirectories.blade.php
+++ b/src/Resources/views/components/tree/damdirectories.blade.php
@@ -303,8 +303,8 @@
                         <i class="icon-dam-folder text-xl transition-all group-hover:text-gray-800 dark:group-hover:text-white cursor-grab"></i>
                     </span>
                     <span 
-                        class="text-sm text-nowrap overflow-hidden text-ellipsis dark:text-white"
-                         :class="selectedItem && formattedItems[0].id == selectedItem.id ? 'text-violet-700' : 'text-zinc-600'"
+                        class="text-sm text-nowrap overflow-hidden text-ellipsis"
+                         :class="selectedItem && formattedItems[0].id == selectedItem.id ? 'text-violet-700 dark:text-violet-400 font-semibold' : 'text-zinc-600 dark:text-white'"
                     >
                         @{{ formattedItems[0].name }}
                     </span>
@@ -1061,11 +1061,16 @@
                     removed
                 } = event;
 
+                if (this.isLoading) {
+                    this.loadDirectories();
+                    return;
+                }
+
                 if (!this.dragStart) {
                     this.loadDirectories();
                     return;
                 }
-                
+
                 this.dragStart = false;
                 
                 let moved = added || removed;
@@ -1123,6 +1128,9 @@
             },
 
             addedItems(item, moveTodirectoryId, type = 'directory') {
+                this.isLoading = true;
+                this.actionStatus = 'pending';
+
                 this.$axios.post(type == 'directory' ? "{{ route('admin.dam.directory.moved') }}" : "{{ route('admin.dam.assets.moved') }}", {
                         new_parent_id: moveTodirectoryId,
                         move_item_id: item.id,
@@ -1132,10 +1140,20 @@
                             type: 'success',
                             message: response.data.message
                         });
-                        this.loadDirectories();
+
+                        if (type == 'directory') {
+                            setTimeout(() => {
+                                this.checkActionStatus('move_directory_structure');
+                            }, 1000);
+                        } else {
+                            this.isLoading = false;
+                            this.actionStatus = null;
+                            this.loadDirectories();
+                        }
                     })
                     .catch(error => {
                         this.isLoading = false;
+                        this.actionStatus = null;
                         this.$emitter.emit('add-flash', {
                             type: 'error',
                             message: error.response.data.message
@@ -1257,6 +1275,7 @@
                     }, 1000);
 
                     this.isLoading = false;
+                    this.actionStatus = null;
 
                     this.$emitter.emit('add-flash', {
                         type: 'success',
@@ -1297,7 +1316,11 @@
             },
 
             goForNextAction(action) {
-                if (action == 'delete_directory' || action == 'copy_directory_structure') {
+                if (
+                    action == 'delete_directory'
+                    || action == 'copy_directory_structure'
+                    || action == 'move_directory_structure'
+                ) {
                     this.loadDirectories();
                 }
             }

--- a/src/Traits/Directory.php
+++ b/src/Traits/Directory.php
@@ -3,8 +3,6 @@
 namespace Webkul\DAM\Traits;
 
 use Illuminate\Support\Facades\Storage;
-use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\ImageManager;
 use Webkul\DAM\Models\Asset;
 use Webkul\DAM\Models\Directory as ModelDirectory;
 
@@ -92,6 +90,8 @@ trait Directory
 
     public function getMetadata(string $path, string $disk)
     {
+        $tempFile = null;
+
         try {
             $storage = Storage::disk($disk);
 
@@ -99,23 +99,21 @@ trait Directory
                 throw new \Exception(trans('dam::app.admin.dam.asset.edit.image-source-not-readable'));
             }
 
-            $fileContent = $storage->get($path);
-            $image = (new ImageManager(new Driver))->read($fileContent);
-            // Get absolute path (IMPORTANT for exif)
-            $fullPath = $storage->path($path);
+            // getimagesize / exif_read_data require a real local filesystem
+            // path. On non-local drivers (e.g. S3) Storage::path() returns only
+            // the object key, so we materialize the object into a temp file.
+            $tempFile = tempnam(sys_get_temp_dir(), 'dam_meta_');
+            file_put_contents($tempFile, $storage->get($path));
 
-            // Basic image info
-            $imageInfo = getimagesize($fullPath);
-
-            // EXIF data (only works for jpeg/tiff)
-            $exif = @exif_read_data($fullPath) ?: [];
+            $imageInfo = @getimagesize($tempFile) ?: [];
+            $exif = @exif_read_data($tempFile) ?: [];
 
             $metadata = [
-                'FileName'      => basename($fullPath),
-                'FileDateTime'  => (int) filemtime($fullPath),
-                'FileSize'      => filesize($fullPath),
+                'FileName'      => basename($path),
+                'FileDateTime'  => (int) ($storage->lastModified($path) ?? @filemtime($tempFile)),
+                'FileSize'      => (int) ($storage->size($path) ?? @filesize($tempFile)),
                 'FileType'      => $imageInfo[2] ?? null,
-                'MimeType'      => $imageInfo['mime'] ?? null,
+                'MimeType'      => $imageInfo['mime'] ?? ($storage->mimeType($path) ?: null),
                 'SectionsFound' => implode(', ', array_keys($exif)),
                 'COMPUTED'      => [
                     'html'    => $imageInfo[3] ?? null,
@@ -130,13 +128,16 @@ trait Directory
                 'data'    => $metadata,
             ];
         } catch (\Exception $e) {
-
             report($e);
 
             return [
                 'success' => false,
                 'message' => trans('dam::app.admin.dam.asset.edit.failed-to-read', ['exception' => $e->getMessage()]),
             ];
+        } finally {
+            if ($tempFile && file_exists($tempFile)) {
+                @unlink($tempFile);
+            }
         }
     }
 }

--- a/src/Traits/Directory.php
+++ b/src/Traits/Directory.php
@@ -106,7 +106,8 @@ trait Directory
             file_put_contents($tempFile, $storage->get($path));
 
             $imageInfo = @getimagesize($tempFile) ?: [];
-            $exif = @exif_read_data($tempFile) ?: [];
+
+            $exif = function_exists('exif_read_data') ? (@exif_read_data($tempFile) ?: []) : [];
 
             $metadata = [
                 'FileName'      => basename($path),

--- a/tests/DamTestCase.php
+++ b/tests/DamTestCase.php
@@ -3,9 +3,12 @@
 namespace Webkul\DAM\Tests;
 
 use Tests\TestCase;
+use Webkul\AdminApi\Tests\Traits\ApiHelperTrait;
 use Webkul\User\Tests\Concerns\UserAssertions;
 
 class DamTestCase extends TestCase
 {
-    use UserAssertions;
+    use ApiHelperTrait, UserAssertions {
+        UserAssertions::getFullTableName insteadof ApiHelperTrait;
+    }
 }

--- a/tests/Feature/Api/AssetApiTest.php
+++ b/tests/Feature/Api/AssetApiTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Webkul\DAM\Models\Asset;
+use Webkul\DAM\Models\Directory;
+
+beforeEach(function () {
+    Storage::fake(Directory::getAssetDisk());
+    $this->headers = $this->getAuthenticationHeaders();
+});
+
+it('lists assets via the api index endpoint', function () {
+    Asset::factory()->count(2)->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.assets.index'));
+
+    $response->assertOk();
+});
+
+it('shows an asset via the api show endpoint', function () {
+    $asset = Asset::factory()->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.assets.show', $asset->id));
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.asset.id', $asset->id);
+});
+
+it('returns 404 when showing a non-existent asset via api', function () {
+    $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.assets.show', 999999))
+        ->assertStatus(404)
+        ->assertJsonPath('success', false);
+});
+
+it('returns edit payload for an asset via api', function () {
+    $asset = Asset::factory()->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.assets.edit', $asset->id));
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.asset.id', $asset->id);
+});
+
+it('returns 404 when editing a non-existent asset via api', function () {
+    $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.assets.edit', 999999))
+        ->assertStatus(404);
+});
+
+it('updates an asset via the api update endpoint', function () {
+    $asset = Asset::factory()->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.assets.update', $asset->id), [
+            'file_name' => 'renamed.png',
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas($this->getFullTableName(Asset::class), [
+        'id'        => $asset->id,
+        'file_name' => 'renamed.png',
+    ]);
+});
+
+it('returns 404 when updating a non-existent asset via api', function () {
+    $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.assets.update', 999999), ['file_name' => 'x.png'])
+        ->assertStatus(404);
+});
+
+it('uploads an asset via the api upload endpoint', function () {
+    $disk = Directory::getAssetDisk();
+    Storage::disk($disk)->makeDirectory('assets/New');
+
+    $directory = Directory::factory()->create(['name' => 'New', 'parent_id' => null]);
+
+    $file = UploadedFile::fake()->image('api-upload.png', 200, 200);
+
+    $response = $this->withHeaders($this->headers)
+        ->post(route('admin.api.dam.assets.upload'), [
+            'files'        => [$file],
+            'directory_id' => $directory->id,
+        ]);
+
+    $response->assertStatus(201)->assertJsonPath('success', true);
+});
+
+it('validates directory_id on api upload', function () {
+    $response = $this->withHeaders($this->headers)
+        ->postJson(route('admin.api.dam.assets.upload'), []);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['directory_id']);
+});
+
+it('deletes an asset via the api destroy endpoint', function () {
+    $disk = Directory::getAssetDisk();
+    $path = 'assets/Root/api-destroy.png';
+    Storage::disk($disk)->put($path, 'x');
+
+    $asset = Asset::factory()->create(['path' => $path]);
+
+    $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.assets.destroy', $asset->id))
+        ->assertOk()
+        ->assertJsonPath('success', true);
+
+    $this->assertDatabaseMissing($this->getFullTableName(Asset::class), ['id' => $asset->id]);
+});
+
+it('returns 404 when destroying a non-existent asset via api', function () {
+    $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.assets.destroy', 999999))
+        ->assertStatus(404);
+});
+
+it('returns 404 when downloading a missing asset via api', function () {
+    $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.assets.download', 999999))
+        ->assertStatus(404);
+});
+
+it('returns a signed-url download response for an existing asset', function () {
+    $disk = Directory::getAssetDisk();
+    $path = 'assets/Root/download.png';
+    Storage::disk($disk)->put($path, 'content');
+
+    $asset = Asset::factory()->create(['path' => $path]);
+
+    $response = $this->withHeaders($this->headers)
+        ->get(route('admin.api.dam.assets.private.download', $asset->id));
+
+    $response->assertOk();
+});

--- a/tests/Feature/Api/CommentApiTest.php
+++ b/tests/Feature/Api/CommentApiTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Webkul\DAM\Models\Asset;
+use Webkul\DAM\Models\AssetComments;
+
+beforeEach(function () {
+    $this->headers = $this->getAuthenticationHeaders();
+});
+
+it('fetches a comment by id via api', function () {
+    $asset = Asset::factory()->create();
+    $comment = AssetComments::factory()->create(['dam_asset_id' => $asset->id]);
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.comment.get', $comment->id));
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.id', $comment->id);
+});
+
+it('returns 404 when comment not found via api', function () {
+    $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.comment.get', 999999))
+        ->assertStatus(404);
+});
+
+it('creates a new comment via api', function () {
+    $asset = Asset::factory()->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->postJson(route('admin.api.dam.comment.store'), [
+            'comments'     => 'Looks good',
+            'dam_asset_id' => $asset->id,
+        ]);
+
+    $response->assertStatus(201)->assertJsonStructure(['comment']);
+
+    $this->assertDatabaseHas('dam_asset_comments', [
+        'comments'     => 'Looks good',
+        'dam_asset_id' => $asset->id,
+    ]);
+});
+
+it('validates comment creation fields via api', function () {
+    $this->withHeaders($this->headers)
+        ->postJson(route('admin.api.dam.comment.store'), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['comments', 'dam_asset_id']);
+});
+
+it('updates an existing comment via api', function () {
+    $asset = Asset::factory()->create();
+    $comment = AssetComments::factory()->create(['dam_asset_id' => $asset->id]);
+
+    $response = $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.comment.update', $comment->id), [
+            'comments' => 'updated text',
+        ]);
+
+    $response->assertOk()->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('dam_asset_comments', [
+        'id'       => $comment->id,
+        'comments' => 'updated text',
+    ]);
+});
+
+it('returns 404 when updating a non-existent comment via api', function () {
+    $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.comment.update', 999999), ['comments' => 'x'])
+        ->assertStatus(404);
+});
+
+it('deletes a comment via api', function () {
+    $asset = Asset::factory()->create();
+    $comment = AssetComments::factory()->create(['dam_asset_id' => $asset->id]);
+
+    $response = $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.comment.delete', $comment->id));
+
+    $response->assertOk()->assertJsonPath('success', true);
+    $this->assertDatabaseMissing('dam_asset_comments', ['id' => $comment->id]);
+});
+
+it('returns 404 when deleting a non-existent comment via api', function () {
+    $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.comment.delete', 999999))
+        ->assertStatus(404);
+});

--- a/tests/Feature/Api/DirectoryApiTest.php
+++ b/tests/Feature/Api/DirectoryApiTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use Webkul\DAM\Jobs\DeleteDirectory as DeleteDirectoryJob;
+use Webkul\DAM\Jobs\RenameDirectory as RenameDirectoryJob;
+use Webkul\DAM\Models\Directory;
+
+beforeEach(function () {
+    Storage::fake(Directory::getAssetDisk());
+    $this->headers = $this->getAuthenticationHeaders();
+});
+
+it('returns the directory tree via api index', function () {
+    Directory::factory()->create(['name' => 'Root']);
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.directory.index'));
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonStructure(['data']);
+});
+
+it('creates a new directory via api', function () {
+    $disk = Directory::getAssetDisk();
+    Storage::disk($disk)->makeDirectory('assets/ApiRoot');
+
+    $parent = Directory::factory()->create(['name' => 'ApiRoot', 'parent_id' => null]);
+
+    $response = $this->withHeaders($this->headers)
+        ->postJson(route('admin.api.dam.directory.store'), [
+            'name'      => 'API Child',
+            'parent_id' => $parent->id,
+        ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('dam_directories', ['name' => 'API Child', 'parent_id' => $parent->id]);
+});
+
+it('returns a single directory by id via api', function () {
+    $directory = Directory::factory()->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.directory.get', $directory->id));
+
+    $response->assertOk()->assertJsonPath('success', true);
+});
+
+it('returns 404 when directory not found via api', function () {
+    $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.directory.get', 999999))
+        ->assertStatus(404);
+});
+
+it('renames a directory and dispatches rename job via api', function () {
+    $disk = Directory::getAssetDisk();
+    Storage::disk($disk)->makeDirectory('assets/OldApiDir');
+    Bus::fake();
+
+    $directory = Directory::factory()->create(['name' => 'OldApiDir', 'parent_id' => null]);
+
+    $response = $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.directory.update', $directory->id), [
+            'name' => 'RenamedApiDir',
+        ]);
+
+    $response->assertOk()->assertJsonPath('success', true);
+    Bus::assertDispatched(RenameDirectoryJob::class);
+});
+
+it('returns 404 when updating a non-existent directory via api', function () {
+    $this->withHeaders($this->headers)
+        ->putJson(route('admin.api.dam.directory.update', 999999), ['name' => 'X'])
+        ->assertStatus(404);
+});
+
+it('dispatches delete job for a deletable directory via api', function () {
+    Bus::fake();
+    $directory = Directory::factory()->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.directory.delete', $directory->id));
+
+    $response->assertStatus(202)->assertJsonPath('success', true);
+    Bus::assertDispatched(DeleteDirectoryJob::class);
+});
+
+it('returns 404 when deleting a non-existent directory via api', function () {
+    $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.directory.delete', 999999))
+        ->assertStatus(404);
+});

--- a/tests/Feature/Api/LinkedResourcesApiTest.php
+++ b/tests/Feature/Api/LinkedResourcesApiTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Webkul\Category\Models\Category;
+use Webkul\DAM\Models\Asset;
+use Webkul\DAM\Models\AssetResourceMapping;
+
+beforeEach(function () {
+    $this->headers = $this->getAuthenticationHeaders();
+});
+
+it('returns a linked resource by id via api', function () {
+    $asset = Asset::factory()->create();
+    $category = Category::factory()->create();
+
+    $mapping = AssetResourceMapping::create([
+        'type'          => 'category',
+        'category_id'   => $category->id,
+        'dam_asset_id'  => $asset->id,
+        'related_field' => 'icon',
+    ]);
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.linked_resource.get', $mapping->id));
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.id', $mapping->id);
+});
+
+it('returns 404 when linked resource is not found via api', function () {
+    $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.linked_resource.get', 999999))
+        ->assertStatus(404);
+});

--- a/tests/Feature/Api/PropertyApiTest.php
+++ b/tests/Feature/Api/PropertyApiTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Webkul\Core\Models\Locale;
+use Webkul\DAM\Models\Asset;
+use Webkul\DAM\Models\AssetProperty;
+
+beforeEach(function () {
+    $this->headers = $this->getAuthenticationHeaders();
+});
+
+it('fetches a property by id via api', function () {
+    $asset = Asset::factory()->create();
+    $property = AssetProperty::factory()->create(['dam_asset_id' => $asset->id]);
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.property.get', $property->id));
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.id', $property->id);
+});
+
+it('returns 404 when property is not found via api', function () {
+    $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.property.get', 999999))
+        ->assertStatus(404);
+});
+
+it('adds a new property via api', function () {
+    $asset = Asset::factory()->create();
+    $locale = Locale::where('status', 1)->first();
+
+    $response = $this->withHeaders($this->headers)
+        ->postJson(route('admin.api.dam.property.add', $asset->id), [
+            'name'     => 'Author Name',
+            'type'     => 'text',
+            'language' => $locale->code,
+            'value'    => 'John Doe',
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('dam_asset_properties', [
+        'dam_asset_id' => $asset->id,
+        'name'         => 'Author Name',
+        'value'        => 'John Doe',
+    ]);
+});
+
+it('validates property creation fields via api', function () {
+    $asset = Asset::factory()->create();
+
+    $this->withHeaders($this->headers)
+        ->postJson(route('admin.api.dam.property.add', $asset->id), [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['name', 'type', 'language', 'value']);
+});
+
+it('rejects property creation for unknown locale via api', function () {
+    $asset = Asset::factory()->create();
+
+    $response = $this->withHeaders($this->headers)
+        ->postJson(route('admin.api.dam.property.add', $asset->id), [
+            'name'     => 'Field',
+            'type'     => 'text',
+            'language' => 'zz_ZZ',
+            'value'    => 'v',
+        ]);
+
+    $response->assertStatus(400)->assertJsonPath('success', false);
+});
+
+it('updates a property via api', function () {
+    $asset = Asset::factory()->create();
+    $property = AssetProperty::factory()->create(['dam_asset_id' => $asset->id]);
+
+    $response = $this->withHeaders($this->headers)
+        ->patchJson(route('admin.api.dam.property.update', $property->id), [
+            'name'  => 'Updated Name',
+            'value' => 'new value',
+        ]);
+
+    $response->assertOk()->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('dam_asset_properties', [
+        'id'    => $property->id,
+        'name'  => 'Updated Name',
+        'value' => 'new value',
+    ]);
+});
+
+it('returns 404 when updating a non-existent property via api', function () {
+    $this->withHeaders($this->headers)
+        ->patchJson(route('admin.api.dam.property.update', 999999), [
+            'name'  => 'X',
+            'value' => 'v',
+        ])
+        ->assertStatus(404);
+});
+
+it('deletes a property via api', function () {
+    $asset = Asset::factory()->create();
+    $property = AssetProperty::factory()->create(['dam_asset_id' => $asset->id]);
+
+    $response = $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.property.delete', $property->id));
+
+    $response->assertOk()->assertJsonPath('success', true);
+    $this->assertDatabaseMissing('dam_asset_properties', ['id' => $property->id]);
+});
+
+it('returns 404 when deleting a non-existent property via api', function () {
+    $this->withHeaders($this->headers)
+        ->deleteJson(route('admin.api.dam.property.delete', 999999))
+        ->assertStatus(404);
+});

--- a/tests/Feature/Api/TagApiTest.php
+++ b/tests/Feature/Api/TagApiTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Webkul\DAM\Models\Tag;
+
+beforeEach(function () {
+    $this->headers = $this->getAuthenticationHeaders();
+});
+
+it('fetches a tag by id via api', function () {
+    $tag = Tag::create(['name' => 'api-tag']);
+
+    $response = $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.tags.get', $tag->id));
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.id', $tag->id);
+});
+
+it('returns 404 when tag not found via api', function () {
+    $this->withHeaders($this->headers)
+        ->getJson(route('admin.api.dam.tags.get', 999999))
+        ->assertStatus(404);
+});

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Webkul\DAM\Models\Asset;
 use Webkul\DAM\Models\AssetResourceMapping;
@@ -343,6 +344,36 @@ it('should validate upload requires files and directory_id', function () {
 
     $response->assertStatus(422)
         ->assertJsonValidationErrors(['files', 'directory_id']);
+});
+
+// Mass Update Asset
+it('should mass update assets and dispatch update events', function () {
+    Event::fake();
+
+    $assetIds = Asset::factory()->createMany(2)->pluck('id')->toArray();
+
+    $this->postJson(route('admin.dam.assets.mass_update'), [
+        'indices' => $assetIds,
+        'value'   => 'enabled',
+    ])
+        ->assertOk()
+        ->assertJsonFragment(['message' => trans('dam::app.admin.dam.asset.datagrid.mass-update-success')]);
+
+    foreach ($assetIds as $id) {
+        Event::assertDispatched('dam.asset.update.before', fn ($event, $payload) => $payload === $id);
+        Event::assertDispatched('dam.asset.update.after', fn ($event, $payload) => $payload === $id);
+    }
+});
+
+// Linked Resources DataGrid
+it('should return linked resources datagrid as json', function () {
+    Asset::factory()->create();
+
+    $response = $this->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+        ->get(route('admin.dam.asset.linked_resources.index'));
+
+    $response->assertOk();
+    expect($response->json())->toBeArray();
 });
 
 // Move the Assets

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -8,6 +8,7 @@ use Webkul\DAM\Models\Directory;
 
 beforeEach(function () {
     $this->loginAsAdmin();
+    Storage::fake(Directory::getAssetDisk());
 });
 
 // Index Page for DAM Asset
@@ -62,8 +63,9 @@ it('should update the asset details successfully', function () {
 
 // Upload Asset File
 it('should upload the asset file to the specified directory', function () {
-    Storage::fake('private');
-    Storage::disk('private')->makeDirectory('assets/New');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
+    Storage::disk($disk)->makeDirectory('assets/New');
 
     $directory = Directory::factory()->create([
         'name'      => 'New',
@@ -87,7 +89,7 @@ it('should upload the asset file to the specified directory', function () {
     $uploadedFileName = $response->json('files.0.file_name');
     $uploadedPath = $response->json('files.0.path');
 
-    Storage::disk('private')->assertExists($uploadedPath);
+    Storage::disk($disk)->assertExists($uploadedPath);
 
     $this->assertDatabaseHas($this->getFullTableName(Asset::class), [
         'file_name' => $uploadedFileName,
@@ -97,7 +99,8 @@ it('should upload the asset file to the specified directory', function () {
 
 // Re-Upload Asset File
 it('should re-upload the asset file to the specified directory and update the asset record', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
     $directory = Directory::factory()->create(['name' => 'Root']);
 
@@ -110,7 +113,7 @@ it('should re-upload the asset file to the specified directory and update the as
 
     $asset->directories()->attach($directory->id);
 
-    Storage::disk('private')->put($initialFilePath, 'dummy content');
+    Storage::disk($disk)->put($initialFilePath, 'dummy content');
 
     $newFile = UploadedFile::fake()->image('sample.png', 600, 600)->size(23);
 
@@ -126,12 +129,12 @@ it('should re-upload the asset file to the specified directory and update the as
         ])
         ->assertJsonPath('file.id', $asset->id);
 
-    Storage::disk('private')->assertMissing($initialFilePath);
+    Storage::disk($disk)->assertMissing($initialFilePath);
 
     $newFileName = $response->json('file.file_name');
     $expectedNewPath = 'assets/Root/'.$newFileName;
 
-    Storage::disk('private')->assertExists($expectedNewPath);
+    Storage::disk($disk)->assertExists($expectedNewPath);
 
     $this->assertDatabaseHas($this->getFullTableName(Asset::class), [
         'id'        => $asset->id,
@@ -166,11 +169,12 @@ it('should mass delete the asset successfully', function () {
 
 // Download the Asset
 it('should allow downloading the asset file', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
     $fileName = 'sample-'.uniqid().'.pdf';
     $filePath = 'assets/Root/'.$fileName;
-    Storage::disk('private')->put($filePath, 'dummy content');
+    Storage::disk($disk)->put($filePath, 'dummy content');
 
     $asset = Asset::factory()->create([
         'file_name' => $fileName,
@@ -205,7 +209,8 @@ it('should allow custom downloading of the asset', function () {
 
 // Rename File
 it('should rename the file name', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
     $originalName = 'original-name-'.uniqid().'.pdf';
     $newName = 'renamed-file-'.uniqid().'.pdf';
@@ -214,7 +219,7 @@ it('should rename the file name', function () {
     $originalPath = $directory.$originalName;
     $newPath = $directory.$newName;
 
-    Storage::disk('private')->put($originalPath, 'dummy content');
+    Storage::disk($disk)->put($originalPath, 'dummy content');
 
     $file = Asset::factory()->create([
         'file_name' => $originalName,
@@ -238,15 +243,16 @@ it('should rename the file name', function () {
         'path'      => $newPath,
     ]);
 
-    Storage::disk('private')->assertMissing($originalPath);
+    Storage::disk($disk)->assertMissing($originalPath);
 
-    Storage::disk('private')->assertExists($newPath);
+    Storage::disk($disk)->assertExists($newPath);
 });
 
 // Upload forbidden file type
 it('should reject uploading a forbidden file type', function () {
-    Storage::fake('private');
-    Storage::disk('private')->makeDirectory('assets/New');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
+    Storage::disk($disk)->makeDirectory('assets/New');
 
     $directory = Directory::factory()->create([
         'name'      => 'New',
@@ -341,10 +347,11 @@ it('should validate upload requires files and directory_id', function () {
 
 // Move the Assets
 it('should move asset from one directory to another', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
-    Storage::disk('private')->makeDirectory('assets/Root');
-    Storage::disk('private')->makeDirectory('assets/Root/Screenshots');
+    Storage::disk($disk)->makeDirectory('assets/Root');
+    Storage::disk($disk)->makeDirectory('assets/Root/Screenshots');
 
     $rootDir = Directory::factory()->create(['name' => 'Root']);
     $newDirectory = Directory::factory()->create(['name' => 'Screenshots', 'parent_id' => $rootDir->id]);
@@ -352,7 +359,7 @@ it('should move asset from one directory to another', function () {
     $fileName = 'sample-'.uniqid().'.jpg';
     $originalPath = 'assets/Root/'.$fileName;
 
-    Storage::disk('private')->put($originalPath, 'dummy content');
+    Storage::disk($disk)->put($originalPath, 'dummy content');
 
     $asset = Asset::factory()->create([
         'file_name' => $fileName,
@@ -375,7 +382,7 @@ it('should move asset from one directory to another', function () {
     $expectedPath = 'assets/Root/Screenshots/'.$fileName;
     $this->assertEquals($expectedPath, $updatedAsset->path);
 
-    Storage::disk('private')->assertExists($expectedPath);
+    Storage::disk($disk)->assertExists($expectedPath);
 
-    Storage::disk('private')->assertMissing($originalPath);
+    Storage::disk($disk)->assertMissing($originalPath);
 });

--- a/tests/Feature/CommentTest.php
+++ b/tests/Feature/CommentTest.php
@@ -121,6 +121,15 @@ it('should validate comment is required', function () {
         ->assertJsonValidationErrors(['comments']);
 });
 
+it('should validate name and value when updating a comment', function () {
+    $asset = Asset::factory()->create();
+
+    $response = $this->putJson(route('admin.dam.asset.comment.update', $asset->id), []);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['name', 'value']);
+});
+
 it('should return user info with timezone', function () {
     $admin = Admin::first();
 

--- a/tests/Feature/DirectoryTest.php
+++ b/tests/Feature/DirectoryTest.php
@@ -74,8 +74,9 @@ it('returns assets of the directory when directory exists (many-to-many)', funct
 
 it('should create new directory', function () {
 
-    Storage::fake('private');
-    Storage::disk('private')->makeDirectory('assets/New');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
+    Storage::disk($disk)->makeDirectory('assets/New');
 
     $directory = Directory::factory()->create([
         'name'      => 'New',
@@ -104,6 +105,10 @@ it('should create new directory', function () {
 });
 
 it('updates a directory name and dispatches RenameDirectoryJob', function () {
+
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
+    Storage::disk($disk)->makeDirectory('assets');
 
     $directory = Directory::factory()->create([
         'name' => 'Old Name',

--- a/tests/Feature/DirectoryTest.php
+++ b/tests/Feature/DirectoryTest.php
@@ -298,3 +298,13 @@ it('should validate move_item_id and new_parent_id are required', function () {
     $response->assertStatus(422)
         ->assertJsonValidationErrors(['move_item_id', 'new_parent_id']);
 });
+
+it('should respond successfully to legacy directory copy endpoint', function () {
+    $response = $this->postJson(route('admin.dam.directory.copy'), [
+        'id'        => 1,
+        'parent_id' => 1,
+    ]);
+
+    $response->assertOk()
+        ->assertJson(['message' => 'Folder copy successfully.', 'data' => null]);
+});

--- a/tests/Feature/FileTest.php
+++ b/tests/Feature/FileTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Webkul\DAM\Models\Directory;
+
+beforeEach(function () {
+    $this->loginAsAdmin();
+    Storage::fake(Directory::getAssetDisk());
+});
+
+it('should create a file in private storage and return its path', function () {
+    $file = UploadedFile::fake()->image('create.png', 100, 100);
+
+    $response = $this->postJson(route('admin.dam.file.create'), ['file' => $file]);
+
+    $response->assertOk()->assertJsonStructure(['path']);
+
+    Storage::disk(Directory::getAssetDisk())->assertExists($response->json('path'));
+});
+
+it('should delete an existing file from private storage', function () {
+    $disk = Directory::getAssetDisk();
+    $path = 'random/files/sample.png';
+    Storage::disk($disk)->put($path, 'dummy');
+
+    $response = $this->deleteJson(route('admin.dam.file.delete'), ['path' => $path]);
+
+    $response->assertOk()->assertJson(['status' => 'File deleted']);
+    Storage::disk($disk)->assertMissing($path);
+});
+
+it('should return 404 when deleting a non-existent file', function () {
+    $response = $this->deleteJson(route('admin.dam.file.delete'), ['path' => 'no/such/file.png']);
+
+    $response->assertStatus(404)->assertJson(['error' => 'File not found']);
+});
+
+it('should update the file by replacing existing content', function () {
+    $disk = Directory::getAssetDisk();
+    $oldPath = 'random/files/old.png';
+    Storage::disk($disk)->put($oldPath, 'old');
+
+    $newFile = UploadedFile::fake()->image('new.png', 50, 50);
+
+    $response = $this->call('PUT', route('admin.dam.file.update'), ['path' => $oldPath], [], ['file' => $newFile]);
+
+    $response->assertOk()->assertJsonStructure(['new_path']);
+    Storage::disk($disk)->assertMissing($oldPath);
+    Storage::disk($disk)->assertExists($response->json('new_path'));
+});
+
+it('should return 404 when updating a non-existent file', function () {
+    $newFile = UploadedFile::fake()->image('new.png', 50, 50);
+
+    $response = $this->call('PUT', route('admin.dam.file.update'), ['path' => 'missing/path.png'], [], ['file' => $newFile]);
+
+    $response->assertStatus(404)->assertJson(['error' => 'File not found']);
+});
+
+it('should fetch an existing file with the correct mime type', function () {
+    $disk = Directory::getAssetDisk();
+    $path = 'assets/Root/sample.png';
+    Storage::disk($disk)->put($path, 'binary-data');
+
+    $response = $this->get(route('admin.dam.file.fetch', ['path' => $path]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain('image/');
+});
+
+it('should return 404 when fetching a non-existent file', function () {
+    $response = $this->getJson(route('admin.dam.file.fetch', ['path' => 'assets/none.png']));
+
+    $response->assertStatus(404)->assertJson(['error' => 'File not found']);
+});
+
+it('should serve a default thumbnail when the file is not an image', function () {
+    $disk = Directory::getAssetDisk();
+    $path = 'assets/Root/document.pdf';
+    Storage::disk($disk)->put($path, 'pdf-content');
+
+    Storage::fake('public');
+    Storage::disk('public')->put('dam/grid/file.svg', '<svg/>');
+
+    $response = $this->call('GET', route('admin.dam.file.thumbnail'), ['path' => $path]);
+
+    $response->assertOk();
+});
+
+it('should redirect thumbnail requests from unauthenticated users', function () {
+    auth()->guard('admin')->logout();
+
+    $response = $this->call('GET', route('admin.dam.file.thumbnail'), ['path' => 'assets/Root/x.png']);
+
+    expect($response->getStatusCode())->toBe(302);
+});
+
+it('should redirect preview requests from unauthenticated users', function () {
+    auth()->guard('admin')->logout();
+
+    $response = $this->call('GET', route('admin.dam.file.preview'), ['path' => 'assets/Root/x.png']);
+
+    expect($response->getStatusCode())->toBe(302);
+});
+
+it('should serve a default preview when the file does not exist', function () {
+    Storage::fake('public');
+    Storage::disk('public')->put('dam/preview/file.svg', '<svg/>');
+
+    $response = $this->call('GET', route('admin.dam.file.preview'), ['path' => 'assets/Root/missing.pdf']);
+
+    $response->assertOk();
+});

--- a/tests/Unit/AssetPropertyPresenterTest.php
+++ b/tests/Unit/AssetPropertyPresenterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Webkul\Core\Models\Locale;
+use Webkul\DAM\Presenters\AssetProperty as Presenter;
+
+it('returns label and raw values for non-language fields', function () {
+    $result = Presenter::representValueForHistory('Old Name', 'New Name', 'name');
+
+    expect($result)->toBe([
+        'name' => [
+            'name' => 'Property Name',
+            'old'  => 'Old Name',
+            'new'  => 'New Name',
+        ],
+    ]);
+});
+
+it('falls back to empty string when values are null', function () {
+    $result = Presenter::representValueForHistory(null, null, 'value');
+
+    expect($result['value']['old'])->toBe('');
+    expect($result['value']['new'])->toBe('');
+    expect($result['value']['name'])->toBe('Property Value');
+});
+
+it('translates locale ids to locale names for the language field', function () {
+    $oldLocale = Locale::first();
+    $newLocale = Locale::skip(1)->first() ?? $oldLocale;
+
+    $result = Presenter::representValueForHistory($oldLocale->id, $newLocale->id, 'language');
+
+    expect($result['language']['name'])->toBe('Property Language');
+    expect($result['language']['old'])->toBe($oldLocale->name);
+    expect($result['language']['new'])->toBe($newLocale->name);
+});

--- a/tests/Unit/AssetResourceMappingRepositoryTest.php
+++ b/tests/Unit/AssetResourceMappingRepositoryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Webkul\Category\Models\Category;
+use Webkul\DAM\Models\Asset;
+use Webkul\DAM\Models\AssetResourceMapping;
+use Webkul\DAM\Repositories\AssetResourceMappingRepository;
+use Webkul\Product\Models\Product;
+
+beforeEach(function () {
+    $this->repo = app(AssetResourceMappingRepository::class);
+});
+
+function productId(): int
+{
+    return Product::factory()->simple()->create()->id;
+}
+
+function categoryId(): int
+{
+    return Category::factory()->create()->id;
+}
+
+it('creates product asset mappings for a list of assets', function () {
+    $assets = Asset::factory()->createMany(2);
+    $productId = productId();
+
+    $created = $this->repo->createProductAssetMappings($assets, $productId, 'image');
+
+    expect($created)->toHaveCount(2);
+
+    foreach ($assets as $asset) {
+        $this->assertDatabaseHas('dam_asset_resource_mappings', [
+            'product_id'    => $productId,
+            'dam_asset_id'  => $asset->id,
+            'related_field' => 'image',
+            'type'          => AssetResourceMappingRepository::PRODUCT_TYPE_MAPPING,
+        ]);
+    }
+});
+
+it('does not duplicate product mappings when assets already linked', function () {
+    $asset = Asset::factory()->create();
+    $productId = productId();
+
+    $this->repo->createProductAssetMappings(collect([$asset]), $productId, 'image');
+    $this->repo->createProductAssetMappings(collect([$asset]), $productId, 'image');
+
+    $count = AssetResourceMapping::where('product_id', $productId)
+        ->where('related_field', 'image')
+        ->count();
+
+    expect($count)->toBe(1);
+});
+
+it('removes stale product mappings on subsequent sync', function () {
+    [$first, $second] = Asset::factory()->createMany(2);
+    $productId = productId();
+
+    $this->repo->createProductAssetMappings(collect([$first, $second]), $productId, 'image');
+    $this->repo->createProductAssetMappings(collect([$second]), $productId, 'image');
+
+    $this->assertDatabaseMissing('dam_asset_resource_mappings', [
+        'product_id'   => $productId,
+        'dam_asset_id' => $first->id,
+    ]);
+    $this->assertDatabaseHas('dam_asset_resource_mappings', [
+        'product_id'   => $productId,
+        'dam_asset_id' => $second->id,
+    ]);
+});
+
+it('creates category asset mappings with category type', function () {
+    $assets = Asset::factory()->createMany(2);
+    $categoryId = categoryId();
+
+    $created = $this->repo->createCategoryAssetMappings($assets, $categoryId, 'icon');
+
+    expect($created)->toHaveCount(2);
+    foreach ($assets as $asset) {
+        $this->assertDatabaseHas('dam_asset_resource_mappings', [
+            'category_id'   => $categoryId,
+            'dam_asset_id'  => $asset->id,
+            'related_field' => 'icon',
+            'type'          => AssetResourceMappingRepository::CATEGORY_TYPE_MAPPING,
+        ]);
+    }
+});
+
+it('deletes product mappings for a given product and field', function () {
+    $assets = Asset::factory()->createMany(2);
+    $productId = productId();
+    $this->repo->createProductAssetMappings($assets, $productId, 'banner');
+
+    $this->repo->deleteProductAssetMappings($productId, 'banner');
+
+    $this->assertDatabaseMissing('dam_asset_resource_mappings', [
+        'product_id'    => $productId,
+        'related_field' => 'banner',
+    ]);
+});
+
+it('deletes category mappings for a given category and field', function () {
+    $assets = Asset::factory()->createMany(2);
+    $categoryId = categoryId();
+    $this->repo->createCategoryAssetMappings($assets, $categoryId, 'thumbnail');
+
+    $this->repo->deleteCategoryAssetMappings($categoryId, 'thumbnail');
+
+    $this->assertDatabaseMissing('dam_asset_resource_mappings', [
+        'category_id'   => $categoryId,
+        'related_field' => 'thumbnail',
+    ]);
+});
+
+it('accepts asset ids as integers when creating mappings', function () {
+    $asset = Asset::factory()->create();
+    $productId = productId();
+
+    $created = $this->repo->createProductAssetMappings([$asset->id], $productId, 'image');
+
+    expect($created)->toHaveCount(1);
+    $this->assertDatabaseHas('dam_asset_resource_mappings', [
+        'product_id'   => $productId,
+        'dam_asset_id' => $asset->id,
+    ]);
+});

--- a/tests/Unit/AssetRuleTest.php
+++ b/tests/Unit/AssetRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Webkul\Attribute\Models\Attribute;
+use Webkul\DAM\Rules\AssetRule;
+
+it('passes when value is non-empty for a required attribute', function () {
+    $attribute = new Attribute(['is_required' => true]);
+    $rule = new AssetRule($attribute);
+
+    $failed = false;
+    $rule->validate('field', ['1', '2'], function () use (&$failed) {
+        $failed = true;
+    });
+
+    expect($failed)->toBeFalse();
+});
+
+it('fails when value is empty for a required attribute', function () {
+    $attribute = new Attribute(['is_required' => true]);
+    $rule = new AssetRule($attribute);
+
+    $failed = false;
+    $message = null;
+    $rule->validate('field', [null, '', false], function ($msg) use (&$failed, &$message) {
+        $failed = true;
+        $message = $msg;
+    });
+
+    expect($failed)->toBeTrue();
+    expect($message)->toBe(trans('dam::app.admin.validation.asset.required'));
+});
+
+it('does not fail for an empty value when attribute is not required', function () {
+    $attribute = new Attribute(['is_required' => false]);
+    $rule = new AssetRule($attribute);
+
+    $failed = false;
+    $rule->validate('field', [], function () use (&$failed) {
+        $failed = true;
+    });
+
+    expect($failed)->toBeFalse();
+});

--- a/tests/Unit/JobsTest.php
+++ b/tests/Unit/JobsTest.php
@@ -50,7 +50,8 @@ it('delete directory job is queueable', function () {
 });
 
 it('delete directory job deletes directory and its assets', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
     $parent = Directory::factory()->create(['name' => 'Parent']);
     $directory = Directory::factory()->create(['name' => 'ToDelete', 'parent_id' => $parent->id]);
@@ -61,8 +62,8 @@ it('delete directory job deletes directory and its assets', function () {
     ]);
     $directory->assets()->attach($asset->id);
 
-    Storage::disk('private')->put('assets/Parent/ToDelete/test.jpg', 'content');
-    Storage::disk('private')->makeDirectory('assets/Parent/ToDelete');
+    Storage::disk($disk)->put('assets/Parent/ToDelete/test.jpg', 'content');
+    Storage::disk($disk)->makeDirectory('assets/Parent/ToDelete');
 
     $directoryId = $directory->id;
 
@@ -97,7 +98,7 @@ it('rename directory job is queueable', function () {
 });
 
 it('rename directory job updates asset paths', function () {
-    Storage::fake('private');
+    Storage::fake(Directory::getAssetDisk());
 
     $parent = Directory::factory()->create(['name' => 'Root']);
     $directory = Directory::factory()->create(['name' => 'NewName', 'parent_id' => $parent->id]);
@@ -141,12 +142,13 @@ it('copy directory structure job is queueable', function () {
 });
 
 it('copy directory structure creates a new directory with copy suffix', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
     $parent = Directory::factory()->create(['name' => 'Root']);
     $directory = Directory::factory()->create(['name' => 'Original', 'parent_id' => $parent->id]);
 
-    Storage::disk('private')->makeDirectory('assets/Root/Original');
+    Storage::disk($disk)->makeDirectory('assets/Root/Original');
 
     createPendingActionRequest('copy_directory_structure');
 
@@ -173,14 +175,15 @@ it('dispatches move directory structure job', function () {
 });
 
 it('move directory structure job changes parent', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
     $root = Directory::factory()->create(['name' => 'Root']);
     $source = Directory::factory()->create(['name' => 'Source', 'parent_id' => $root->id]);
     $target = Directory::factory()->create(['name' => 'Target', 'parent_id' => $root->id]);
 
-    Storage::disk('private')->makeDirectory('assets/Root/Source');
-    Storage::disk('private')->makeDirectory('assets/Root/Target');
+    Storage::disk($disk)->makeDirectory('assets/Root/Source');
+    Storage::disk($disk)->makeDirectory('assets/Root/Target');
 
     createPendingActionRequest('move_directory_structure');
 
@@ -192,7 +195,8 @@ it('move directory structure job changes parent', function () {
 });
 
 it('move directory structure job updates asset paths', function () {
-    Storage::fake('private');
+    $disk = Directory::getAssetDisk();
+    Storage::fake($disk);
 
     $root = Directory::factory()->create(['name' => 'Root']);
     $source = Directory::factory()->create(['name' => 'Source', 'parent_id' => $root->id]);
@@ -204,9 +208,9 @@ it('move directory structure job updates asset paths', function () {
     ]);
     $source->assets()->attach($asset->id);
 
-    Storage::disk('private')->makeDirectory('assets/Root/Source');
-    Storage::disk('private')->makeDirectory('assets/Root/Target');
-    Storage::disk('private')->put('assets/Root/Source/file.jpg', 'content');
+    Storage::disk($disk)->makeDirectory('assets/Root/Source');
+    Storage::disk($disk)->makeDirectory('assets/Root/Target');
+    Storage::disk($disk)->put('assets/Root/Source/file.jpg', 'content');
 
     createPendingActionRequest('move_directory_structure');
 

--- a/tests/Unit/ListenerTest.php
+++ b/tests/Unit/ListenerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Webkul\Category\Contracts\CategoryField;
+use Webkul\Category\Repositories\CategoryFieldRepository;
+use Webkul\DAM\Listeners\Category as CategoryListener;
+use Webkul\DAM\Listeners\Product as ProductListener;
+use Webkul\DAM\Models\Asset;
+use Webkul\DAM\Repositories\AssetRepository;
+use Webkul\DAM\Repositories\AssetResourceMappingRepository;
+
+/** Product listener */
+it('creates product asset mappings for active asset attributes with values', function () {
+    $assetField = Mockery::mock();
+    $assetField->code = 'image_field';
+    $assetField->shouldReceive('getValueFromProductValues')->andReturn('1,2');
+
+    $relation = Mockery::mock();
+    $relation->shouldReceive('where')->with('attributes.type', 'asset')->andReturnSelf();
+    $relation->shouldReceive('get')->andReturn(collect([$assetField]));
+
+    $family = Mockery::mock();
+    $family->shouldReceive('customAttributes')->andReturn($relation);
+
+    $product = (object) [
+        'values'           => ['common' => ['image_field' => '1,2']],
+        'id'               => 42,
+        'attribute_family' => $family,
+    ];
+
+    $assets = collect([new Asset(['id' => 1]), new Asset(['id' => 2])]);
+
+    $assetRepo = Mockery::mock(AssetRepository::class);
+    $assetRepo->shouldReceive('findWhereIn')->with('id', [1, 2])->andReturn($assets);
+
+    $mappingRepo = Mockery::mock(AssetResourceMappingRepository::class);
+    $mappingRepo->shouldReceive('createProductAssetMappings')
+        ->once()
+        ->with($assets, 42, 'image_field')
+        ->andReturn([]);
+    $mappingRepo->shouldNotReceive('deleteProductAssetMappings');
+
+    (new ProductListener($assetRepo, $mappingRepo))->afterCreateOrupdate($product);
+});
+
+it('deletes product asset mappings when asset value is empty', function () {
+    $assetField = Mockery::mock();
+    $assetField->code = 'banner';
+    $assetField->shouldReceive('getValueFromProductValues')->andReturn(null);
+
+    $relation = Mockery::mock();
+    $relation->shouldReceive('where')->andReturnSelf();
+    $relation->shouldReceive('get')->andReturn(collect([$assetField]));
+
+    $family = Mockery::mock();
+    $family->shouldReceive('customAttributes')->andReturn($relation);
+
+    $product = (object) [
+        'values'           => [],
+        'id'               => 7,
+        'attribute_family' => $family,
+    ];
+
+    $assetRepo = Mockery::mock(AssetRepository::class);
+    $assetRepo->shouldNotReceive('findWhereIn');
+
+    $mappingRepo = Mockery::mock(AssetResourceMappingRepository::class);
+    $mappingRepo->shouldReceive('deleteProductAssetMappings')
+        ->once()
+        ->with(7, 'banner');
+
+    (new ProductListener($assetRepo, $mappingRepo))->afterCreateOrupdate($product);
+});
+
+/** Category listener */
+it('creates category asset mappings using common additional data', function () {
+    $assetField = Mockery::mock(CategoryField::class);
+    $assetField->code = 'icon';
+    $assetField->shouldReceive('isLocaleBasedField')->andReturn(false);
+
+    $category = (object) [
+        'additional_data' => ['common' => ['icon' => '5']],
+        'id'              => 11,
+    ];
+
+    $assets = collect([new Asset(['id' => 5])]);
+
+    $assetRepo = Mockery::mock(AssetRepository::class);
+    $assetRepo->shouldReceive('findWhereIn')->with('id', ['5'])->andReturn($assets);
+
+    $categoryFieldRepo = Mockery::mock(CategoryFieldRepository::class);
+    $categoryFieldRepo->shouldReceive('findWhere')
+        ->with(['status' => 1, 'type' => 'asset'])
+        ->andReturn(collect([$assetField]));
+
+    $mappingRepo = Mockery::mock(AssetResourceMappingRepository::class);
+    $mappingRepo->shouldReceive('createCategoryAssetMappings')
+        ->once()
+        ->with($assets, 11, 'icon')
+        ->andReturn([]);
+
+    (new CategoryListener($assetRepo, $categoryFieldRepo, $mappingRepo))->afterUpdateOrCreate($category);
+});
+
+it('deletes category asset mappings when value is missing', function () {
+    $assetField = Mockery::mock(CategoryField::class);
+    $assetField->code = 'icon';
+    $assetField->shouldReceive('isLocaleBasedField')->andReturn(false);
+
+    $category = (object) [
+        'additional_data' => ['common' => []],
+        'id'              => 99,
+    ];
+
+    $assetRepo = Mockery::mock(AssetRepository::class);
+    $assetRepo->shouldNotReceive('findWhereIn');
+
+    $categoryFieldRepo = Mockery::mock(CategoryFieldRepository::class);
+    $categoryFieldRepo->shouldReceive('findWhere')->andReturn(collect([$assetField]));
+
+    $mappingRepo = Mockery::mock(AssetResourceMappingRepository::class);
+    $mappingRepo->shouldReceive('deleteCategoryAssetMappings')
+        ->once()
+        ->with(99, 'icon');
+
+    (new CategoryListener($assetRepo, $categoryFieldRepo, $mappingRepo))->afterUpdateOrCreate($category);
+});

--- a/tests/e2e-pw/tests/03-asset-upload.spec.js
+++ b/tests/e2e-pw/tests/03-asset-upload.spec.js
@@ -131,19 +131,18 @@ test.describe('DAM Asset Upload', () => {
   test('Filter button opens filter panel', async ({ adminPage }) => {
     await navigateTo(adminPage, 'dam');
     await adminPage.waitForLoadState('domcontentloaded');
-    // Give Vue time to mount the drawer toggle's @click handler before clicking.
-    await adminPage.waitForTimeout(1000);
 
-    // Click the toolbar's Filter button. Target the icon-filter span specifically
-    // (its parent div has the drawer toggle handler) — the bare "Filter" text can
-    // race with translation/render and miss the click handler entirely.
     const filterToggle = adminPage.locator('span.icon-filter').first();
     await filterToggle.waitFor({ state: 'visible', timeout: 30000 });
-    await filterToggle.click();
 
-    await expect(
-      adminPage.locator('#app').getByText('Apply Filters')
-    ).toBeVisible({ timeout: 15000 });
+    // Vue binds the drawer's @click="open" handler after hydration; a click
+    // that lands before that window hits the span but never opens the drawer.
+    // Retry the click until the drawer header actually renders.
+    const drawerHeader = adminPage.locator('#app').getByText('Apply Filters');
+    await expect(async () => {
+      await filterToggle.click();
+      await expect(drawerHeader).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 30000 });
   });
 
   test('Per Page dropdown works', async ({ adminPage }) => {

--- a/tests/e2e-pw/tests/03-asset-upload.spec.js
+++ b/tests/e2e-pw/tests/03-asset-upload.spec.js
@@ -135,12 +135,19 @@ test.describe('DAM Asset Upload', () => {
     const filterToggle = adminPage.locator('span.icon-filter').first();
     await filterToggle.waitFor({ state: 'visible', timeout: 30000 });
 
+    // Dismiss any lingering modal overlay that may block clicks in CI
+    const overlay = adminPage.locator('div.fixed.inset-0.bg-gray-500');
+    if (await overlay.isVisible().catch(() => false)) {
+      await adminPage.keyboard.press('Escape');
+      await overlay.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    }
+
     // Vue binds the drawer's @click="open" handler after hydration; a click
     // that lands before that window hits the span but never opens the drawer.
     // Retry the click until the drawer header actually renders.
     const drawerHeader = adminPage.locator('#app').getByText('Apply Filters');
     await expect(async () => {
-      await filterToggle.click();
+      await filterToggle.click({ timeout: 5000 });
       await expect(drawerHeader).toBeVisible({ timeout: 2000 });
     }).toPass({ timeout: 30000 });
   });

--- a/tests/e2e-pw/tests/03-asset-upload.spec.js
+++ b/tests/e2e-pw/tests/03-asset-upload.spec.js
@@ -131,9 +131,19 @@ test.describe('DAM Asset Upload', () => {
   test('Filter button opens filter panel', async ({ adminPage }) => {
     await navigateTo(adminPage, 'dam');
     await adminPage.waitForLoadState('domcontentloaded');
+    // Give Vue time to mount the drawer toggle's @click handler before clicking.
+    await adminPage.waitForTimeout(1000);
 
-    await adminPage.getByText('Filter', { exact: true }).click();
-    await expect(adminPage.getByText('Apply Filters')).toBeVisible({ timeout: 10000 });
+    // Click the toolbar's Filter button. Target the icon-filter span specifically
+    // (its parent div has the drawer toggle handler) — the bare "Filter" text can
+    // race with translation/render and miss the click handler entirely.
+    const filterToggle = adminPage.locator('span.icon-filter').first();
+    await filterToggle.waitFor({ state: 'visible', timeout: 30000 });
+    await filterToggle.click();
+
+    await expect(
+      adminPage.locator('#app').getByText('Apply Filters')
+    ).toBeVisible({ timeout: 15000 });
   });
 
   test('Per Page dropdown works', async ({ adminPage }) => {

--- a/tests/e2e-pw/tests/07-datagrid-operations.spec.js
+++ b/tests/e2e-pw/tests/07-datagrid-operations.spec.js
@@ -44,20 +44,18 @@ test.describe('DAM DataGrid Operations', () => {
   test('Filter panel opens and closes', async ({ adminPage }) => {
     await navigateTo(adminPage, 'dam');
     await adminPage.waitForLoadState('domcontentloaded');
-    // Give Vue time to mount the drawer toggle's @click handler before clicking.
-    await adminPage.waitForTimeout(1000);
 
-    // Click the toolbar's Filter button. Target the icon-filter span specifically
-    // (its parent div has the drawer toggle handler) — the bare "Filter" text can
-    // race with translation/render and miss the click handler entirely.
     const filterToggle = adminPage.locator('span.icon-filter').first();
     await filterToggle.waitFor({ state: 'visible', timeout: 30000 });
-    await filterToggle.click();
 
-    // Drawer animates in (~200ms). Wait for the header text inside the drawer.
-    await expect(
-      adminPage.locator('#app').getByText('Apply Filters')
-    ).toBeVisible({ timeout: 15000 });
+    // Vue binds the drawer's @click="open" handler after hydration; a click
+    // that lands before that window hits the span but never opens the drawer.
+    // Retry the click until the drawer header actually renders.
+    const drawerHeader = adminPage.locator('#app').getByText('Apply Filters');
+    await expect(async () => {
+      await filterToggle.click();
+      await expect(drawerHeader).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 30000 });
 
     // Close filter
     await adminPage.keyboard.press('Escape');

--- a/tests/e2e-pw/tests/07-datagrid-operations.spec.js
+++ b/tests/e2e-pw/tests/07-datagrid-operations.spec.js
@@ -48,12 +48,19 @@ test.describe('DAM DataGrid Operations', () => {
     const filterToggle = adminPage.locator('span.icon-filter').first();
     await filterToggle.waitFor({ state: 'visible', timeout: 30000 });
 
+    // Dismiss any lingering modal overlay that may block clicks in CI
+    const overlay = adminPage.locator('div.fixed.inset-0.bg-gray-500');
+    if (await overlay.isVisible().catch(() => false)) {
+      await adminPage.keyboard.press('Escape');
+      await overlay.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    }
+
     // Vue binds the drawer's @click="open" handler after hydration; a click
     // that lands before that window hits the span but never opens the drawer.
     // Retry the click until the drawer header actually renders.
     const drawerHeader = adminPage.locator('#app').getByText('Apply Filters');
     await expect(async () => {
-      await filterToggle.click();
+      await filterToggle.click({ timeout: 5000 });
       await expect(drawerHeader).toBeVisible({ timeout: 2000 });
     }).toPass({ timeout: 30000 });
 

--- a/tests/e2e-pw/tests/07-datagrid-operations.spec.js
+++ b/tests/e2e-pw/tests/07-datagrid-operations.spec.js
@@ -44,12 +44,22 @@ test.describe('DAM DataGrid Operations', () => {
   test('Filter panel opens and closes', async ({ adminPage }) => {
     await navigateTo(adminPage, 'dam');
     await adminPage.waitForLoadState('domcontentloaded');
+    // Give Vue time to mount the drawer toggle's @click handler before clicking.
+    await adminPage.waitForTimeout(1000);
 
-    // Open filter
-    await adminPage.getByText('Filter', { exact: true }).click();
-    await expect(adminPage.getByText('Apply Filters')).toBeVisible({ timeout: 10000 });
+    // Click the toolbar's Filter button. Target the icon-filter span specifically
+    // (its parent div has the drawer toggle handler) — the bare "Filter" text can
+    // race with translation/render and miss the click handler entirely.
+    const filterToggle = adminPage.locator('span.icon-filter').first();
+    await filterToggle.waitFor({ state: 'visible', timeout: 30000 });
+    await filterToggle.click();
 
-    // Close filter (click outside or close button)
+    // Drawer animates in (~200ms). Wait for the header text inside the drawer.
+    await expect(
+      adminPage.locator('#app').getByText('Apply Filters')
+    ).toBeVisible({ timeout: 15000 });
+
+    // Close filter
     await adminPage.keyboard.press('Escape');
     await adminPage.waitForTimeout(300);
   });


### PR DESCRIPTION
## Summary

 Bug fix release for UnoPim DAM v2.0.1 (compatible with UnoPim v2.0.0).

 - **S3 — Single asset move**: Fixed an issue where moving a single asset on S3 orphaned the object.
 - **S3 — Directory rename**: Fixed directory move by relocating files individually (S3 doesn't support directory operations).
 - **S3 — Asset metadata**: Fixed metadata extraction by using temporary local copies and storage-level values.
 - **Missing EXIF extension**: Prevented fatal errors when EXIF extension is not installed.
 - **PostgreSQL — SQL compatibility**: Fixed MySQL-specific queries causing errors on PostgreSQL.
 - **Dark mode — Root Category label**: Fixed text visibility in dark mode.